### PR TITLE
Simple preprocessing script to fix common annotation mistakes before tree validation

### DIFF
--- a/preprocess_before_validation.py
+++ b/preprocess_before_validation.py
@@ -1,0 +1,26 @@
+import sys
+
+def process_file(input_file, output_file):
+    with open(input_file, 'r') as infile:
+        lines = infile.readlines()
+    
+    processed_lines = []
+    for line in lines:
+        # Replace tabs with four spaces
+        line = line.replace('\t', '    ')
+        # Remove trailing whitespace
+        line = line.rstrip()
+        processed_lines.append(line)
+    
+    with open(output_file, 'w') as outfile:
+        for line in processed_lines:
+            outfile.write(line + '\n')
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python preprocess-before-validation.py <input_file> <output_file>")
+        sys.exit(1)
+    
+    input_file = sys.argv[1]
+    output_file = sys.argv[2]
+    process_file(input_file, output_file)

--- a/preprocess_before_validation.py
+++ b/preprocess_before_validation.py
@@ -18,7 +18,7 @@ def process_file(input_file, output_file):
 
 if __name__ == "__main__":
     if len(sys.argv) != 3:
-        print("Usage: python preprocess-before-validation.py <input_file> <output_file>")
+        print("Usage: python preprocess_before_validation.py <input_file> <output_file>")
         sys.exit(1)
     
     input_file = sys.argv[1]


### PR DESCRIPTION
When I run validate_trees.py, I frequently get errors due to the following low-level annotation mistakes:

- Making indents with \t rather than space characters 
- Trailing whitespace at the end of lines 

To fix these mistakes automatically, I've found it helpful to run this preprocessing script on my .cgel annotation files prior to running validate_trees.py. Submitting for your consideration! 