### PR TITLE
manual 'punct' switch for tree.ptb() call in cgel2ptb.py

### DIFF
--- a/cgel2ptb.py
+++ b/cgel2ptb.py
@@ -8,6 +8,7 @@ from itertools import chain
 import fileinput
 
 MODE = ['tags', 'trees'][1]
+PUNCT = [True, False][0]
 #with open('datasets/twitter.cgel') as f, open('datasets/ewt.cgel') as f2, open('datasets/ewt-new1-nschneid.cgel') as f3:
 for tree in cgel.trees(fileinput.input()):
-    print(tree.tagging(gap_symbol='_.') if MODE=='tags' else tree.ptb())
+    print(tree.tagging(gap_symbol='_.') if MODE=='tags' else tree.ptb(punct = PUNCT))


### PR DESCRIPTION
Minor update to `cgel2ptb.py`. (Mostly serves to remind the user that the `.ptb()` method has a `punct` parameter). 