### PR TITLE
implement activedop ptree escaping in .ptb_rec() method

### DIFF
--- a/cgel.py
+++ b/cgel.py
@@ -394,8 +394,14 @@ class Tree:
         node = self.tokens[head]
         if punct:
             for p in node.prepunct:
-                p = p.replace('(', '-LRB-').replace(')', '-RRB-')
-                result += f'({p} {p}) ' # add constit for punctuation
+                if p == "(":
+                    result += "(LRB-p -LRB-) "
+                elif p == ")":
+                    result += "(RRB-p -RRB-) "
+                elif p == "-":
+                    result += "(HYPH-p -) "
+                else:
+                    result += f'({p}-p {p}) ' # add constit for punctuation
         result += node.ptb()    # main contents of this node
         if node.constituent != 'GAP':
             # recursion to child nodes
@@ -404,8 +410,14 @@ class Tree:
         result += ')'
         if punct:
             for p in node.postpunct:
-                p = p.replace('(', '-LRB-').replace(')', '-RRB-')
-                result += f' ({p} {p})' # add constit for punctuation
+                if p == "(":
+                    result += "(LRB-p -LRB-) "
+                elif p == ")":
+                    result += "(RRB-p -RRB-) "
+                elif p == "-":
+                    result += "(HYPH-p -) "
+                else:
+                    result += f'({p}-p {p}) ' # add constit for punctuation
         return result
 
     def ptb(self, punct: bool=True):

--- a/cgel2ptb.py
+++ b/cgel2ptb.py
@@ -8,6 +8,7 @@ from itertools import chain
 import fileinput
 
 MODE = ['tags', 'trees'][1]
+PUNCT = [True, False][0]
 #with open('datasets/twitter.cgel') as f, open('datasets/ewt.cgel') as f2, open('datasets/ewt-new1-nschneid.cgel') as f3:
 for tree in cgel.trees(fileinput.input()):
-    print(tree.tagging(gap_symbol='_.') if MODE=='tags' else tree.ptb())
+    print(tree.tagging(gap_symbol='_.') if MODE=='tags' else tree.ptb(punct = PUNCT))


### PR DESCRIPTION
We frequently call the `.ptb()` method in activedop to convert cgeltrees to trees exposed to the dopparser (ptrees). (And we use the script `activedopexport2cgel.py` -- which invokes the `.ptb()` method -- to convert cgeltrees to a format that discodop can train on. This proposed change just updates how `.ptb()` escapes certain punctuation sequences. 

If it's inconvenient to make this change to the method directly, I could also create a method with the desired behavior called sth like `.ptree()` (and an associated `activedopexport2ptree.py` script). 