### PR TITLE
Predicative vs. catenative complements

### DIFF
--- a/cgel.py
+++ b/cgel.py
@@ -908,6 +908,12 @@ class Tree:
                     elif ch.constituent=='Clause':
                         assert ch.constituent=='Clause' and c_d!=('Clause_rel', 'Head'),self.draw_rec(p,0)
                         assert ch.constituent=='Clause' and c_d!=('Clause', 'Comp'),self.draw_rec(p,0)
+                        if ch.deprel=='PredComp' and par.constituent!='NP+Clause':
+                            # only PredComp if complement of 'be' (setting aside absolute constructions)
+                            head_sisters = [x for x in children if x.deprel=='Head']
+                            assert head_sisters,self.draw_rec(p,0)
+                            head_sister, = head_sisters
+                            assert par.constituent=='VP' and head_sister.lemma=='be',self.draw_rec(p,0)
                     elif ch.constituent=='Clause_rel':
                         assert ch.constituent=='Clause_rel' and c_d!=('Clause', 'Head'),self.draw_rec(p,0)
 
@@ -1070,7 +1076,7 @@ class Tree:
                         assert ch.constituent=='PP'
                         assert par.constituent=='VP'
                     elif ch.deprel=='PredComp':
-                        assert ch.constituent!='AdvP'
+                        assert ch.constituent not in ('AdvP', 'Clause_rel', 'DP', 'IntP', 'Nom', 'PP_strand', 'VP')
                         assert par.constituent=='VP' or '+' in par.constituent or par.constituent=='PP' and self.tokens[cc[0]].lemma=='as',self.draw_rec(p,0)
                     elif ch.deprel=='Marker':
                         assert ch.constituent in ('Coordinator','Sdr','DP'),self.draw_rec(p,0)  # DP for "both" (X and Y)

--- a/datasets/ewt-test_iaa50.cgel
+++ b/datasets/ewt-test_iaa50.cgel
@@ -1726,7 +1726,7 @@
                         :Marker (Sdr :t "to")
                         :Head (VP
                             :Head (V :t "leave" :xpos "VB")
-                            :PredComp (Coordination
+                            :Mod (Coordination :note "optional depictive"
                                 :Coordinate (PP
                                     :Head (P :t "without")
                                     :Obj (NP

--- a/datasets/oneoff/uniform.cgel
+++ b/datasets/oneoff/uniform.cgel
@@ -105,7 +105,7 @@
                                                             :Head (N :t "letters" :l "letter")))
                                                     :Head (VP
                                                         :Head (V :t "got" :l "get" :xpos "VBD")
-                                                        :PredComp (Clause
+                                                        :Comp (Clause :note "catenative complement (https://github.com/nert-nlp/cgel/pull/145)"
                                                             :Head (VP
                                                                 :Head (V :t "wrinkled" :l "wrinkle" :xpos "VBN")
                                                                 :Comp (PP

--- a/datasets/oneoff/usc-acreage.cgel
+++ b/datasets/oneoff/usc-acreage.cgel
@@ -88,7 +88,7 @@
                     :Head (V_aux :t "are" :l "be" :xpos "VBP")
                     :Mod (AdvP
                         :Head (Adv :t "not")))
-                :PredComp (Clause
+                :Comp (Clause
                     :Head (VP
                         :Head (V :t "classified" :l "classify" :xpos "VBN")
                         :Comp (PP

--- a/datasets/oneoff/xkcd-garden-path.cgel
+++ b/datasets/oneoff/xkcd-garden-path.cgel
@@ -45,7 +45,7 @@
                                                             :Mod (AdjP
                                                                 :Head (Adj :t "green"))
                                                             :Head (N :t "walkways" :l "walkway")))))))))
-                            :PredComp (Clause
+                            :Comp (Clause :note "catenative complement (https://github.com/nert-nlp/cgel/issues/145)"
                                 :Head (VP
                                     :Head (V :t "vacated" :l "vacate" :xpos "VBN"))))))))
         :Head (Coordination

--- a/datasets/twitter.cgel
+++ b/datasets/twitter.cgel
@@ -174,7 +174,7 @@
                 :Head (N_pro :t "it")))
         :Head (VP
             :Head (V_aux :t "isn't" :l "be" :xpos "VBZ" :subt "is" :subt "n't")
-            :PredComp (Clause :note "impersonal construction (p. 960)"
+            :PredComp (Clause :note "p. 962: 'should perhaps be analyzed as...the impersonal construction' (p. 960)"
                 :Marker (Sdr :t "that")
                 :Head (Clause
                     :Subj (NP


### PR DESCRIPTION
While some nonfinite clauses can have resultative or depictive meanings, it seems that they should rarely be treated as PredComps.

For example, past-participial catenative (as opposed to predicative) complements discussed on p. 1245:

<img width="540" alt="image" src="https://github.com/user-attachments/assets/b46df049-53c7-4092-aff2-5a6555a63822">

I believe raising-to-object verbs like *deem*, *find*, *order* license either a PredComp (AdjP or NP) or catenative Comp (nonfinite Clause).